### PR TITLE
Add 'from' Email Variable

### DIFF
--- a/chatgpt_ui_server/settings.py
+++ b/chatgpt_ui_server/settings.py
@@ -179,4 +179,5 @@ EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER', '')
 EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD', '')
 EMAIL_USE_TLS = os.getenv('EMAIL_USE_TLS', True) == 'True'
 EMAIL_USE_SSL = os.getenv('EMAIL_USE_SSL', False) == 'True'
+DEFAULT_FROM_EMAIL = os.getenv('EMAIL_FROM', os.getenv('EMAIL_HOST_USER', ''))
 


### PR DESCRIPTION
Adds listener/processor for environmental variable `EMAIL_FROM`

Defines django config option `DEFAULT_FROM_EMAIL` which allows defining the 'from' email address